### PR TITLE
인기 탑텐 공연 조회 API 구현 & 잔여 좌석수 조회 및 동기화 구현

### DIFF
--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/CacheConfig.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/CacheConfig.java
@@ -1,0 +1,34 @@
+package com.eatpizzaquickly.concertservice.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Configuration
+public class CacheConfig {
+
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    @Bean
+    @Primary
+    public CacheManager redisCacheManager() {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(10));
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/RedisConfig.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/RedisConfig.java
@@ -6,12 +6,20 @@ import org.redisson.client.codec.StringCodec;
 import org.redisson.codec.JsonJacksonCodec;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 public class RedisConfig {

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/controller/ConcertController.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/controller/ConcertController.java
@@ -6,6 +6,7 @@ import com.eatpizzaquickly.concertservice.dto.request.SeatReservationRequest;
 import com.eatpizzaquickly.concertservice.dto.response.ApiResponse;
 import com.eatpizzaquickly.concertservice.dto.response.ConcertDetailResponse;
 import com.eatpizzaquickly.concertservice.dto.response.ConcertListResponse;
+import com.eatpizzaquickly.concertservice.dto.response.PopularConcertResponse;
 import com.eatpizzaquickly.concertservice.service.ConcertService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -13,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/concerts")
@@ -54,5 +57,12 @@ public class ConcertController {
     ) {
         Page<ConcertSimpleDto> concertSimpleDtos = concertService.searchByCategory(category, pageable);
         return ResponseEntity.ok(ApiResponse.success("조회 성공", concertSimpleDtos));
+    }
+
+    @GetMapping("/popular")
+    public ResponseEntity<ApiResponse<PopularConcertResponse>> getTopViewedConcerts() {
+        int limit = 10;
+        List<ConcertSimpleDto> topViewedConcerts = concertService.getTopViewedConcerts(limit);
+        return ResponseEntity.ok(ApiResponse.success("인기 콘서트 조회 성공", PopularConcertResponse.of(topViewedConcerts)));
     }
 }

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/ConcertDetailResponse.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/ConcertDetailResponse.java
@@ -16,15 +16,17 @@ public class ConcertDetailResponse {
     private String title;
     private String location;
     private String description;
+    private Integer seatCount;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
 
-    public static ConcertDetailResponse from(Concert concert, Venue venue) {
+    public static ConcertDetailResponse from(Concert concert, Venue venue, int seatCount) {
         return new ConcertDetailResponse(
                 concert.getId(),
                 concert.getTitle(),
                 venue.getLocation(),
                 concert.getDescription(),
+                seatCount,
                 concert.getStartDate(),
                 concert.getEndDate());
     }

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/PopularConcertResponse.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/PopularConcertResponse.java
@@ -1,0 +1,17 @@
+package com.eatpizzaquickly.concertservice.dto.response;
+
+import com.eatpizzaquickly.concertservice.dto.ConcertSimpleDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class PopularConcertResponse {
+    List<ConcertSimpleDto> concertSimpleDtoList;
+
+    public static PopularConcertResponse of(List<ConcertSimpleDto> concertSimpleDtoList) {
+        return new PopularConcertResponse(concertSimpleDtoList);
+    }
+}

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/repository/ConcertCustomRepositoryImpl.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/repository/ConcertCustomRepositoryImpl.java
@@ -18,7 +18,7 @@ public class ConcertCustomRepositoryImpl implements ConcertCustomRepository{
 
     private final JPAQueryFactory queryFactory;
 
-    @Override
+//    @Override
     public Page<Concert> searchByTitleOrArtists(String keyword, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
 

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/repository/ConcertRedisRepository.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/repository/ConcertRedisRepository.java
@@ -1,10 +1,16 @@
 package com.eatpizzaquickly.concertservice.repository;
 
+import com.eatpizzaquickly.concertservice.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RSet;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -12,15 +18,52 @@ import java.util.List;
 public class ConcertRedisRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final RedissonClient redissonClient;
+
+    // 조회수 증가
+    public void increaseViewCount(Long concertId) {
+        RScoredSortedSet<Long> sortedSet = redissonClient.getScoredSortedSet(RedisUtil.getViewCountKey());
+        sortedSet.addScore(concertId, 1);
+    }
+
+    // 상위 조회수 콘서트 조회
+    public List<Long> getTopViewedConcertIds(int limit) {
+        RScoredSortedSet<Long> sortedSet = redissonClient.getScoredSortedSet(RedisUtil.getViewCountKey());
+        Collection<Long> concertIds = sortedSet.valueRangeReversed(0, limit - 1);
+        return new ArrayList<>(concertIds);
+    }
+
+    // 예약 가능한 좌석을 Redis에 추가
+    public void addAvailableSeats(Long concertId, List<Long> seatIds) {
+        RSet<String> availableSeats = redissonClient.getSet(RedisUtil.getAvailableSeatsKey(concertId));
+        for (Long seatId : seatIds) {
+            availableSeats.add(String.valueOf(seatId));
+        }
+    }
+
+    // Redis에서 잔여 좌석 수 조회
+    public int getAvailableSeatCount(Long concertId) {
+        String redisKey = RedisUtil.getAvailableSeatsKey(concertId);
+        RSet<String> availableSeats = redissonClient.getSet(redisKey);
+        return availableSeats.size();
+    }
+
+    // 좌석을 다시 Redis에 추가 (예약 실패 시)
+    public void addSeatBackToAvailable(Long concertId, Long seatId) {
+        String redisKey = RedisUtil.getAvailableSeatsKey(concertId);
+        RSet<String> availableSeats = redissonClient.getSet(redisKey);
+        availableSeats.add(String.valueOf(seatId));
+    }
 
     public void reserveSeat(Long concertId, Long seatId) {
-        String availableSeatsKey = "concert:" + concertId + ":available_seats";
-        String seatKey = String.valueOf(seatId);
+//        String availableSeatsKey = "concert:" + concertId + ":available_seats";
+        String availableSeatsKey = RedisUtil.getAvailableSeatsKey(concertId);
+        String seatValue = String.valueOf(seatId);
 
         String result = redisTemplate.execute(
                 reserveSeatScript(),
                 List.of(availableSeatsKey),
-                seatKey
+                seatValue
         );
 
         SeatReservationCode.checkReservationResult(SeatReservationCode.find(result));
@@ -38,4 +81,9 @@ public class ConcertRedisRepository {
         return RedisScript.of(script, String.class);
     }
 
+    // Redis 에서 좌석 데이터가 있는지 확인
+    public boolean hasAvailableSeats(Long concertId) {
+        String availableSeatsKey = RedisUtil.getAvailableSeatsKey(concertId);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(availableSeatsKey));
+    }
 }

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/repository/SeatRepository.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/repository/SeatRepository.java
@@ -2,9 +2,15 @@ package com.eatpizzaquickly.concertservice.repository;
 
 import com.eatpizzaquickly.concertservice.entity.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByConcertId(Long concertId);
+
+    // 예약되지 않은 좌석 조회 쿼리
+    @Query("SELECT s FROM Seat s WHERE s.concert.id = :concertId AND s.isReserved = false")
+    List<Seat> findAvailableSeatsByConcertId(@Param("concertId") Long concertId);
 }

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/service/ConcertService.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/service/ConcertService.java
@@ -9,19 +9,24 @@ import com.eatpizzaquickly.concertservice.entity.Concert;
 import com.eatpizzaquickly.concertservice.entity.Seat;
 import com.eatpizzaquickly.concertservice.entity.Venue;
 import com.eatpizzaquickly.concertservice.exception.NotFoundException;
+import com.eatpizzaquickly.concertservice.repository.ConcertRedisRepository;
 import com.eatpizzaquickly.concertservice.repository.ConcertRepository;
 import com.eatpizzaquickly.concertservice.repository.SeatRepository;
 import com.eatpizzaquickly.concertservice.repository.VenueRepository;
+import com.eatpizzaquickly.concertservice.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RMapCache;
+import org.redisson.api.RScoredSortedSet;
 import org.redisson.api.RSet;
 import org.redisson.api.RedissonClient;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -32,7 +37,7 @@ public class ConcertService {
     private final ConcertRepository concertRepository;
     private final VenueRepository venueRepository;
     private final SeatRepository seatRepository;
-    private final RedissonClient redissonClient;
+    private final ConcertRedisRepository concertRedisRepository;
 
     @Transactional
     public ConcertDetailResponse saveConcert(ConcertCreateRequest concertCreateRequest) {
@@ -52,8 +57,6 @@ public class ConcertService {
 
         concertRepository.save(concert);
 
-        RSet<String> availableSeats = redissonClient.getSet("concert:" + concert.getId() + ":available_seats");
-
         List<Seat> seats = new ArrayList<>();
         for (int i = 1; i <= venue.getSeatCount(); i++) {
             Seat seat = Seat.builder()
@@ -67,16 +70,19 @@ public class ConcertService {
         seatRepository.saveAll(seats);
 
         // Redis에 예약 가능한 좌석 세팅
-        for (Seat seat : seats) {
-            availableSeats.add(String.valueOf(seat.getId()));
-        }
+        List<Long> seatIds = seats.stream().map(Seat::getId).toList();
+        concertRedisRepository.addAvailableSeats(concert.getId(), seatIds);
 
-        return ConcertDetailResponse.from(concert, venue);
+        return ConcertDetailResponse.from(concert, venue, venue.getSeatCount());
     }
 
     public ConcertDetailResponse findConcert(Long concertId) {
         Concert concert = concertRepository.findByIdWithVenue(concertId).orElseThrow(NotFoundException::new);
-        return ConcertDetailResponse.from(concert, concert.getVenue());
+        increaseViewCount(concertId);
+
+        int availableSeatCount = concertRedisRepository.getAvailableSeatCount(concertId);
+
+        return ConcertDetailResponse.from(concert, concert.getVenue(), availableSeatCount);
     }
 
     public ConcertListResponse searchConcert(String keyword, Pageable pageable) {
@@ -95,5 +101,16 @@ public class ConcertService {
         Category vaildCategory = Category.of(category);
         Page<Concert> concert = concertRepository.findAllByCategory(vaildCategory, pageable);
         return concert.map(ConcertSimpleDto::from);
+    }
+
+    @Cacheable(value = "topViewedConcerts", key = "#limit", unless = "#result.size() == 0")
+    public List<ConcertSimpleDto> getTopViewedConcerts(int limit) {
+        List<Long> topViewedConcertIds = concertRedisRepository.getTopViewedConcertIds(limit);
+        List<Concert> concerts = concertRepository.findAllById(topViewedConcertIds);
+        return concerts.stream().map(ConcertSimpleDto::from).toList();
+    }
+
+    public void increaseViewCount(Long concertId) {
+        concertRedisRepository.increaseViewCount(concertId);
     }
 }

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/util/RedisUtil.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/util/RedisUtil.java
@@ -1,4 +1,12 @@
 package com.eatpizzaquickly.concertservice.util;
 
 public class RedisUtil {
+
+    public static String getAvailableSeatsKey(long concertId) {
+        return "concert:%s:available_seats".formatted(concertId);
+    }
+
+    public static String getViewCountKey() {
+        return "concert:view_count";
+    }
 }


### PR DESCRIPTION
## 📄 Summary
> 사람들이 많이 조회한 공연 탑 텐을 조회하는 API 와 잔여 좌석수 조회 및 동기화를 구현했습니다.

## 🙋🏻 More
* 조회수는 Redis의 sorted Set 자료형으로 저장되도록 했습니다. 그래서 자연스럽게 인기순으로 정렬됩니다.
* 잔여 좌석수 확인은 공연을 조회할때 Redis 에서 바로 조회 하도록 구현했습니다.
  * 잔여 좌석수를 DB에 실제 업데이트하는 것은 스케쥴링을 이용합니다.

## ✨issue
> This closes #51 
