### PR TITLE
feat: 카프카 트랜잭션 설정 추가

### DIFF
--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/KafkaConfig.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/KafkaConfig.java
@@ -48,6 +48,7 @@ public class KafkaConfig {
         myconfig.put(ProducerConfig.RETRIES_CONFIG, 3);
         myconfig.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 3000);
         myconfig.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 30000);
+        myconfig.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "tx-");
         return new DefaultKafkaProducerFactory<>(myconfig);
     }
 

--- a/reservation-service/src/main/java/com/eatpizzaquickly/reservationservice/common/config/KafkaConfig.java
+++ b/reservation-service/src/main/java/com/eatpizzaquickly/reservationservice/common/config/KafkaConfig.java
@@ -57,6 +57,7 @@ public class KafkaConfig {
         myConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         myConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         myConfig.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        myConfig.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
         return new DefaultKafkaConsumerFactory<>(myConfig);
     }
 


### PR DESCRIPTION
## 📄 Summary
> 이벤트를 발행한 후의 로직에서 예외가 발생히 해당 이벤트를 소비하지 못해야 합니다. 이를 위해 카프카 트랜잭션 설정을 추가했습니다.

## 🙋🏻 More
>

## ✨issue
> This  closes #107 
