### PR TITLE
feat: 여러 조회, 단건 조회 Redis 캐싱 활용 성능 향상

### DIFF
--- a/batch-service/src/main/java/com/eatpizzaquickly/batchservice/common/client/ConcertClient.java
+++ b/batch-service/src/main/java/com/eatpizzaquickly/batchservice/common/client/ConcertClient.java
@@ -5,10 +5,7 @@ import com.eatpizzaquickly.batchservice.settlement.dto.response.ConcertHostRespo
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 @FeignClient(name = "concert-service")
 public interface ConcertClient {
@@ -19,7 +16,7 @@ public interface ConcertClient {
     ResponseEntity<ConcertHostResponseDto> findHostIdsByConcertIds(@RequestBody HostIdRequestDto hostIdRequestDto);
 
     @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "resetTopConcertsFallback")
-    @PostMapping("/api/v1/concerts/top")
+    @DeleteMapping("/api/v1/concerts/top")
     void resetTopConcerts();
 
     // Fallback methods

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/client/RedisCacheSubscriber.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/client/RedisCacheSubscriber.java
@@ -19,6 +19,6 @@ public class RedisCacheSubscriber {
     public void onMessage(String concertId) {
         log.info("Received cache update event for concertId: {}", concertId);
         concertService.findConcert(Long.parseLong(concertId));
-        concertCacheService.putTopViewedConcertsCache();
+        concertCacheService.putTopConcertsCache();
     }
 }

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/CacheConfig.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/CacheConfig.java
@@ -33,21 +33,11 @@ public class CacheConfig {
 
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
                 .entryTtl(Duration.ofMinutes(10));
-
-        // TTL 없는 특정 캐시 설정
-        RedisCacheConfiguration topConcerts = RedisCacheConfiguration.defaultCacheConfig()
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
-                .entryTtl(Duration.ZERO); // TTL 없음
-
-        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
-        cacheConfigurations.put("topConcerts", topConcerts);
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
                 .cacheDefaults(redisCacheConfiguration)
-                .withInitialCacheConfigurations(cacheConfigurations) // 캐시별 설정 추가
                 .build();
     }
 

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/JacksonConfig.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/config/JacksonConfig.java
@@ -1,6 +1,8 @@
 package com.eatpizzaquickly.concertservice.config;
 
 
+import com.eatpizzaquickly.concertservice.dto.response.ConcertDetailResponse;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/controller/ConcertController.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/controller/ConcertController.java
@@ -31,12 +31,13 @@ public class ConcertController {
             @RequestParam(name = "host") Long hostId
     ) {
         ConcertDetailResponse concertDetailResponse = concertService.saveConcert(concertCreateRequest, hostId);
+        concertCacheService.putAllConcertsCache();
         return ResponseEntity.ok(ApiResponse.success("공연 생성 성공", concertDetailResponse));
     }
 
     @GetMapping("/{concertId}")
     public ResponseEntity<ApiResponse<ConcertDetailResponse>> getConcert(@PathVariable Long concertId) {
-        ConcertDetailResponse concertDetailResponse = concertService.findConcert(concertId);
+        ConcertDetailResponse concertDetailResponse = concertCacheService.findConcertWithVenueCache(concertId);
         return ResponseEntity.ok(ApiResponse.success("공연 조회 성공", concertDetailResponse));
     }
 
@@ -45,17 +46,10 @@ public class ConcertController {
         return ResponseEntity.ok(concertService.findHostIdsByConcertIds(hostIdRequestDto));
     }
 
-    ;
-    // 삭제
-//    @GetMapping("/search")
-//    public ResponseEntity<ApiResponse<ConcertListResponse>> getConcertSearchList(@RequestParam(required = false) String keyword, @PageableDefault Pageable pageable) {
-//        ConcertListResponse concertListResponse = concertService.searchConcert(keyword, pageable);
-//        return ResponseEntity.ok(ApiResponse.success("공연 리스트 조회 성공", concertListResponse));
-//    }
-
     @GetMapping
-    public ResponseEntity<ApiResponse<ConcertListResponse>> getConcertList(@PageableDefault Pageable pageable) {
-        ConcertListResponse concertListResponse = concertService.findAllConcerts(pageable);
+    public ResponseEntity<ApiResponse<ConcertListResponse>> getConcertList() {
+//        ConcertListResponse concertListResponse = concertService.findAllConcerts();
+        ConcertListResponse concertListResponse = concertCacheService.findAllConcertsCache();
         return ResponseEntity.ok(ApiResponse.success("공연 조회 성공", concertListResponse));
     }
 
@@ -84,13 +78,12 @@ public class ConcertController {
     @PutMapping("/{concertId}")
     public ResponseEntity<ApiResponse<Void>> updateConcert(@PathVariable Long concertId,
                                                            @RequestBody ConcertUpdateRequest concertUpdateRequest) {
-        concertService.updateConcert(concertId, concertUpdateRequest);
-        String concertTitle = concertService.findConcert(concertId).getTitle();
-        System.out.println("updateConcert:concertTitle = " + concertTitle);
+        concertCacheService.putConcertCache(concertId, concertUpdateRequest);
+        concertCacheService.putAllConcertsCache();
         return ResponseEntity.ok(ApiResponse.success("공연 업데이트 성공"));
     }
 
-    @PostMapping("/top")
+    @DeleteMapping("/top")
     public void resetTopConcerts() {
         concertService.resetTopConcerts();
     }

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/controller/SeatController.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/controller/SeatController.java
@@ -2,6 +2,7 @@ package com.eatpizzaquickly.concertservice.controller;
 
 import com.eatpizzaquickly.concertservice.dto.request.SeatReservationRequest;
 import com.eatpizzaquickly.concertservice.dto.response.ApiResponse;
+import com.eatpizzaquickly.concertservice.dto.response.AvailableSeatCountResponse;
 import com.eatpizzaquickly.concertservice.dto.response.SeatListResponse;
 import com.eatpizzaquickly.concertservice.service.SeatService;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +29,11 @@ public class SeatController {
                                                          @RequestBody SeatReservationRequest seatReservationRequest) {
         seatService.reserveSeat(userId, concertId, seatReservationRequest);
         return ResponseEntity.ok(ApiResponse.success("좌석 예매 성공"));
+    }
+
+    @GetMapping("/{concertId}/seats/count")
+    public ResponseEntity<ApiResponse<AvailableSeatCountResponse>> getAvailableSeatCount(@PathVariable Long concertId) {
+        AvailableSeatCountResponse availableSeatCount = seatService.getAvailableSeatCount(concertId);
+        return ResponseEntity.ok(ApiResponse.success("잔여 좌석 수 조회 성공", availableSeatCount));
     }
 }

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/ConcertSimpleDto.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/ConcertSimpleDto.java
@@ -1,19 +1,37 @@
 package com.eatpizzaquickly.concertservice.dto;
 
 import com.eatpizzaquickly.concertservice.entity.Concert;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class ConcertSimpleDto {
+
     private Long concertId;
+
     private String title;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime startDate;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime endDate;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime performDate;
+
     private String thumbnailUrl;
 
     public static ConcertSimpleDto from(Concert concert) {

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/AvailableSeatCountResponse.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/AvailableSeatCountResponse.java
@@ -1,0 +1,16 @@
+package com.eatpizzaquickly.concertservice.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class AvailableSeatCountResponse {
+    private Integer availableSeatCount;
+
+    public static AvailableSeatCountResponse of(Integer availableSeatCount) {
+        return new AvailableSeatCountResponse(availableSeatCount);
+    }
+}

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/ConcertDetailResponse.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/ConcertDetailResponse.java
@@ -2,6 +2,10 @@ package com.eatpizzaquickly.concertservice.dto.response;
 
 import com.eatpizzaquickly.concertservice.entity.Concert;
 import com.eatpizzaquickly.concertservice.entity.Venue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,9 +22,19 @@ public class ConcertDetailResponse {
     private String description;
     private Integer seatCount;
     private int price;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime startDate;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime endDate;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime performDate;
+
     private String thumbnailUrl;
 
     public static ConcertDetailResponse from(Concert concert, Venue venue, int seatCount) {
@@ -30,6 +44,21 @@ public class ConcertDetailResponse {
                 venue.getLocation(),
                 concert.getDescription(),
                 seatCount,
+                concert.getPrice(),
+                concert.getStartDate(),
+                concert.getEndDate(),
+                concert.getPerformDate(),
+                concert.getThumbnailUrl()
+        );
+    }
+
+    public static ConcertDetailResponse from(Concert concert) {
+        return new ConcertDetailResponse(
+                concert.getId(),
+                concert.getTitle(),
+                concert.getVenue().getLocation(),
+                concert.getDescription(),
+                concert.getVenue().getSeatCount(),
                 concert.getPrice(),
                 concert.getStartDate(),
                 concert.getEndDate(),

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/ConcertListResponse.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/dto/response/ConcertListResponse.java
@@ -3,10 +3,12 @@ package com.eatpizzaquickly.concertservice.dto.response;
 import com.eatpizzaquickly.concertservice.dto.ConcertSimpleDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class ConcertListResponse {
     private List<ConcertSimpleDto> concertSimpleDtoList;

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/service/ConcertCacheService.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/service/ConcertCacheService.java
@@ -1,6 +1,9 @@
 package com.eatpizzaquickly.concertservice.service;
 
 import com.eatpizzaquickly.concertservice.dto.ConcertSimpleDto;
+import com.eatpizzaquickly.concertservice.dto.request.ConcertUpdateRequest;
+import com.eatpizzaquickly.concertservice.dto.response.ConcertDetailResponse;
+import com.eatpizzaquickly.concertservice.dto.response.ConcertListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
@@ -14,14 +17,33 @@ public class ConcertCacheService {
 
     private final ConcertService concertService;
 
-    @Cacheable(value = "topConcerts", cacheManager = "localCacheManager")
+    @Cacheable(value = "top_concerts", cacheManager = "localCacheManager")
     public List<ConcertSimpleDto> getTopConcertsCache() {
         return concertService.getTopConcerts();
     }
 
-    @CachePut(value = "topConcerts", cacheManager = "localCacheManager")
-    public List<ConcertSimpleDto> putTopViewedConcertsCache() {
+    @CachePut(value = "top_concerts", cacheManager = "localCacheManager")
+    public List<ConcertSimpleDto> putTopConcertsCache() {
         return concertService.getTopConcerts();
     }
 
+    @Cacheable(value = "concert_with_venue", key = "#concertId")
+    public ConcertDetailResponse findConcertWithVenueCache(Long concertId) {
+        return concertService.findConcertWithVenue(concertId);
+    }
+
+    @CachePut(value = "concert_with_venue", key = "#concertId")
+    public ConcertDetailResponse putConcertCache(Long concertId, ConcertUpdateRequest concertUpdateRequest) {
+        return concertService.updateConcert(concertId, concertUpdateRequest);
+    }
+
+    @Cacheable(value = "all_concerts")
+    public ConcertListResponse findAllConcertsCache() {
+        return concertService.findAllConcerts();
+    }
+
+    @CachePut(value = "all_concerts")
+    public ConcertListResponse putAllConcertsCache() {
+        return concertService.findAllConcerts();
+    }
  }

--- a/concert-service/src/main/java/com/eatpizzaquickly/concertservice/util/SlackNotifier.java
+++ b/concert-service/src/main/java/com/eatpizzaquickly/concertservice/util/SlackNotifier.java
@@ -1,5 +1,6 @@
 package com.eatpizzaquickly.concertservice.util;
 
+import com.eatpizzaquickly.concertservice.dto.event.ReservationCompensationEvent;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -56,6 +57,20 @@ public class SlackNotifier {
                 consumerRecord.offset(),
                 consumerRecord.value(),
                 exception.getMessage()
+        );
+
+        sendNotification(message);
+    }
+
+    public void notifyCompensateReservationSuccess(ReservationCompensationEvent event) {
+        String message = String.format(
+                """
+                        [보상 트랜잭션 완료]
+                        - Concert ID: %d
+                        - Seat ID: %d
+                        - User ID: %d
+                        """,
+                event.getConcertId(), event.getSeatId(), event.getUserId()
         );
 
         sendNotification(message);


### PR DESCRIPTION
* Redis 캐싱을 활용해서 여러 조회 및 단건 조희의 성능을 향상시켰습니다.
* 공연 상세 조회와 잔여 좌석 수 조회를 분리했습니다.
  * 상세 조회시 캐시 데이터를 조회합니다.
  * 잔여 좌석 수 조회 시 `Set` 자료형으로 있는 `예매 가능한 좌석` 들의 수를 세어서 조회합니다.
    * 시간 복잡도: O(1)

This closes #135 